### PR TITLE
Add falling icon Game page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Contact } from './Features/Contact/Routes';
 import { Technologies } from './Features/Technologies/Routes';
 import { AIApproach } from './Features/AIApproach/Routes';
 import { Patents } from './Features/Patents/Routes';
+import { Game } from './Features/Game/Routes';
 import { NoPage } from './Features/NoPage/Routes';
 import Layout from './Components/Layout/Layout';
 import { Home } from './Features/Home/Routes';
@@ -43,6 +44,8 @@ function App() {
           <Route path="/Patent" element={<Patents />} />
           <Route path="/patentler" element={<Patents />} />
           <Route path="/Patentler" element={<Patents />} />
+          <Route path="/Game" element={<Game />} />
+          <Route path="/game" element={<Game />} />
           <Route path="*" element={<NoPage />} />
         </Routes>
       </Layout>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,4 +1,4 @@
-import { House, EnvelopeSimple, Cpu, Brain, FileText } from 'phosphor-react';
+import { House, EnvelopeSimple, Cpu, Brain, FileText, GameController } from 'phosphor-react';
 import FluidTabs from '../ui/FluidTabs';
 import useWindowWidth from '../../Hooks/useWindowWidth';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +14,7 @@ const Navigation = () => {
     { path: '/Technology', label: t('nav.technologies'), icon: (size: number) => <Cpu size={size} /> },
     { path: '/AI', label: t('nav.aiApproach'), icon: (size: number) => <Brain size={size} /> },
     { path: '/Patent', label: t('nav.patents'), icon: (size: number) => <FileText size={size} /> },
+    { path: '/Game', label: t('nav.game'), icon: (size: number) => <GameController size={size} /> },
   ];
 
   const navItemsWithConditionalLabels = navItems.map(item => ({

--- a/src/features/Game/Routes/index.ts
+++ b/src/features/Game/Routes/index.ts
@@ -1,0 +1,1 @@
+export { default as Game } from '../components/Game';

--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import { GithubLogo, LinkedinLogo, TwitterLogo, YoutubeLogo } from 'phosphor-react';
+import styles from '../styles/Game.module.css';
+
+interface FallingIcon {
+  id: number;
+  left: number;
+  url: string;
+  Element: JSX.Element;
+  cut: boolean;
+}
+
+const icons = [
+  { Element: <LinkedinLogo size={32} />, url: 'https://www.linkedin.com/in/hllbr/' },
+  { Element: <GithubLogo size={32} />, url: 'https://github.com/hllbr' },
+  { Element: <YoutubeLogo size={32} />, url: 'https://www.youtube.com/@platonfarkndapaylasmlar637' },
+  { Element: <TwitterLogo size={32} />, url: 'https://twitter.com' },
+];
+
+const Game = () => {
+  const [falling, setFalling] = useState<FallingIcon[]>([]);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setFalling((prev) => [
+        ...prev,
+        {
+          id: idRef.current++,
+          left: Math.random() * 90,
+          url: icons[idRef.current % icons.length].url,
+          Element: icons[idRef.current % icons.length].Element,
+          cut: false,
+        },
+      ]);
+    }, 1200);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleCut = (id: number) => {
+    setFalling((prev) => prev.map((f) => (f.id === id ? { ...f, cut: true } : f)));
+  };
+
+  const handleAnimationEnd = (icon: FallingIcon) => {
+    setFalling((prev) => prev.filter((f) => f.id !== icon.id));
+    if (!icon.cut) {
+      window.open(icon.url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      {falling.map((icon) => (
+        <div
+          key={icon.id}
+          className={`${styles.icon} ${icon.cut ? styles.cut : ''}`}
+          style={{ left: `${icon.left}%` }}
+          onClick={() => handleCut(icon.id)}
+          onAnimationEnd={() => handleAnimationEnd(icon)}
+        >
+          {icon.Element}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Game;

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -1,0 +1,34 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  overflow: hidden;
+}
+
+.icon {
+  position: absolute;
+  top: -40px;
+  animation-name: fall;
+  animation-timing-function: linear;
+  animation-duration: 4s;
+}
+
+.icon svg {
+  color: #38bdf8;
+  width: 40px;
+  height: 40px;
+}
+
+.icon.cut {
+  opacity: 0.3;
+  transform: rotate(45deg) scale(0.5);
+}
+
+@keyframes fall {
+  from {
+    transform: translateY(-40px);
+  }
+  to {
+    transform: translateY(80vh);
+  }
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "technologies": "Technology",
     "aiApproach": "AI",
     "patents": "Patent",
+    "game": "Game",
     "experience": "Experience",
     "logo": "Portfolio"
   },

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -5,6 +5,7 @@
     "technologies": "Teknoloji",
     "aiApproach": "AI",
     "patents": "Patent",
+    "game": "Oyun",
     "experience": "Deneyimlerim",
     "logo": "Portfolyo"
   },


### PR DESCRIPTION
## Summary
- introduce Game page component that shows falling icons
- style Game page with simple CSS animation
- register Game component for routing
- add Game to navigation menu
- localize navigation label for Game in English and Turkish translations

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module due to path case issues)*

------
https://chatgpt.com/codex/tasks/task_b_684037eeb1e0832cab29a8013732dcf8