### PR TITLE
Fix game over state and add animations

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -10,6 +10,7 @@ interface FallingIcon {
   name: string;
   Element: JSX.Element;
   cut: boolean;
+  animation: string;
 }
 
 const icons = [
@@ -26,6 +27,7 @@ const Game = () => {
   const [score, setScore] = useState(0);
   const [gameOverIcon, setGameOverIcon] = useState<FallingIcon | null>(null);
   const idRef = useRef(0);
+  const animations = ['fall', 'fallRotate', 'fallSpin', 'fallColor'];
 
   useEffect(() => {
     if (!gameStarted || gameOverIcon) return;
@@ -39,6 +41,7 @@ const Game = () => {
           name: icons[idRef.current % icons.length].name,
           Element: icons[idRef.current % icons.length].Element,
           cut: false,
+          animation: animations[Math.floor(Math.random() * animations.length)],
         },
       ]);
     }, 1200);
@@ -52,9 +55,10 @@ const Game = () => {
 
   const handleAnimationEnd = (icon: FallingIcon) => {
     setFalling(prev => prev.filter(f => f.id !== icon.id));
-    if (!icon.cut) {
+    if (!icon.cut && !gameOverIcon) {
       setGameOverIcon(icon);
       setGameStarted(false);
+      setFalling([]);
     }
   };
 
@@ -92,7 +96,7 @@ const Game = () => {
       {falling.map(icon => (
         <div
           key={icon.id}
-          className={`${styles.icon} ${icon.cut ? styles.cut : ''}`}
+          className={`${styles.icon} ${styles[icon.animation]} ${icon.cut ? styles.cut : ''}`}
           style={{ left: `${icon.left}%` }}
           onClick={() => handleCut(icon.id)}
           onAnimationEnd={() => handleAnimationEnd(icon)}

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -13,9 +13,24 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  animation-name: fall;
   animation-timing-function: linear;
   animation-duration: 4s;
+}
+
+.fall {
+  animation-name: fall;
+}
+
+.fallRotate {
+  animation-name: fallRotate;
+}
+
+.fallSpin {
+  animation-name: fallSpin;
+}
+
+.fallColor {
+  animation-name: fallColor;
 }
 
 .icon svg {
@@ -28,6 +43,20 @@
   animation-name: cutAnim;
   animation-duration: 0.3s;
   animation-fill-mode: forwards;
+  position: relative;
+}
+
+.icon.cut::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #f87171;
+  transform: rotate(45deg) scaleX(0);
+  transform-origin: center;
+  animation: sliceLine 0.3s forwards;
 }
 
 @keyframes fall {
@@ -47,6 +76,46 @@
   to {
     transform: rotate(60deg) scale(0.5);
     opacity: 0.3;
+  }
+}
+
+@keyframes sliceLine {
+  from {
+    transform: rotate(45deg) scaleX(0);
+    opacity: 1;
+  }
+  to {
+    transform: rotate(45deg) scaleX(1);
+    opacity: 0;
+  }
+}
+
+@keyframes fallRotate {
+  from {
+    transform: translateY(-40px) rotate(0deg);
+  }
+  to {
+    transform: translateY(80vh) rotate(360deg);
+  }
+}
+
+@keyframes fallSpin {
+  from {
+    transform: translateY(-40px) rotate(0deg);
+  }
+  to {
+    transform: translateY(80vh) rotate(720deg);
+  }
+}
+
+@keyframes fallColor {
+  from {
+    transform: translateY(-40px);
+    color: #38bdf8;
+  }
+  to {
+    transform: translateY(80vh);
+    color: #f43f5e;
   }
 }
 
@@ -127,4 +196,21 @@
   background: transparent;
   color: #e2e8f0;
   border: 1px solid #e2e8f0;
+}
+
+@media (max-width: 640px) {
+  .container {
+    height: 60vh;
+  }
+  .startOverlay {
+    font-size: 1.5rem;
+  }
+  .icon {
+    width: 60px;
+    height: 60px;
+  }
+  .icon svg {
+    width: 48px;
+    height: 48px;
+  }
 }


### PR DESCRIPTION
## Summary
- stop animation updates once game over is triggered
- add random fall animations and slice effect
- improve responsiveness for the game board

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_b_684040a534a0832c815ec2e9befa53ff