### PR TITLE
Add slashing animations and falling color

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -11,6 +11,7 @@ interface FallingIcon {
   Element: JSX.Element;
   cut: boolean;
   animation: string;
+  cutAnimation: string;
 }
 
 const icons = [
@@ -28,6 +29,7 @@ const Game = () => {
   const [gameOverIcon, setGameOverIcon] = useState<FallingIcon | null>(null);
   const idRef = useRef(0);
   const animations = ['fall', 'fallRotate', 'fallSpin', 'fallColor'];
+  const cutAnimations = ['cut', 'cutBlood', 'cutWind'];
 
   useEffect(() => {
     if (!gameStarted || gameOverIcon) return;
@@ -42,6 +44,7 @@ const Game = () => {
           Element: icons[idRef.current % icons.length].Element,
           cut: false,
           animation: animations[Math.floor(Math.random() * animations.length)],
+          cutAnimation: 'cut',
         },
       ]);
     }, 1200);
@@ -49,7 +52,10 @@ const Game = () => {
   }, [gameStarted, gameOverIcon]);
 
   const handleCut = (id: number) => {
-    setFalling(prev => prev.map(f => (f.id === id ? { ...f, cut: true } : f)));
+    const anim = cutAnimations[Math.floor(Math.random() * cutAnimations.length)];
+    setFalling(prev =>
+      prev.map(f => (f.id === id ? { ...f, cut: true, cutAnimation: anim } : f))
+    );
     setScore(prev => prev + 1);
   };
 
@@ -96,7 +102,7 @@ const Game = () => {
       {falling.map(icon => (
         <div
           key={icon.id}
-          className={`${styles.icon} ${styles[icon.animation]} ${icon.cut ? styles.cut : ''}`}
+          className={`${styles.icon} ${styles[icon.animation]} ${icon.cut ? styles[icon.cutAnimation] : ''}`}
           style={{ left: `${icon.left}%` }}
           onClick={() => handleCut(icon.id)}
           onAnimationEnd={() => handleAnimationEnd(icon)}

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -34,7 +34,7 @@
 }
 
 .icon svg {
-  color: #38bdf8;
+  color: inherit;
   width: 64px;
   height: 64px;
 }
@@ -57,6 +57,48 @@
   transform: rotate(45deg) scaleX(0);
   transform-origin: center;
   animation: sliceLine 0.3s forwards;
+}
+
+.icon.cutBlood {
+  animation: cutBloodAnim 0.4s forwards;
+  position: relative;
+  overflow: visible;
+}
+
+.icon.cutBlood::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  background: #f43f5e;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  box-shadow:
+    0 0 0 2px #f43f5e,
+    10px -5px 0 3px #f43f5e,
+    -12px 4px 0 4px #f43f5e,
+    6px 9px 0 3px #f43f5e,
+    -8px -7px 0 2px #f43f5e;
+  animation: bloodSplash 0.4s forwards;
+}
+
+.icon.cutWind {
+  animation: cutWindAnim 0.5s forwards;
+  position: relative;
+}
+
+.icon.cutWind::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -30px;
+  width: 60px;
+  height: 2px;
+  background: #f8fafc;
+  transform: translateY(-50%) scaleX(0);
+  animation: windTrail 0.5s forwards;
 }
 
 @keyframes fall {
@@ -86,6 +128,54 @@
   }
   to {
     transform: rotate(45deg) scaleX(1);
+    opacity: 0;
+  }
+}
+
+@keyframes cutBloodAnim {
+  from {
+    transform: rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: rotate(120deg) scale(0.3);
+    opacity: 0;
+  }
+}
+
+@keyframes bloodSplash {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.8;
+  }
+  70% {
+    transform: translate(-50%, -50%) scale(1.8);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.2);
+    opacity: 0;
+  }
+}
+
+@keyframes cutWindAnim {
+  from {
+    transform: rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100px) rotate(90deg) scale(0.4);
+    opacity: 0;
+  }
+}
+
+@keyframes windTrail {
+  from {
+    transform: translateY(-50%) scaleX(0);
+    opacity: 0.8;
+  }
+  to {
+    transform: translateY(-50%) scaleX(1);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- enhance Game screen with random cut animations
- update cut animation logic to randomly use wind or blood effects
- allow icon color to change while falling
- add CSS keyframes for new cut effects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module './Features/Contact/Routes')*


------
https://chatgpt.com/codex/tasks/task_b_684042deed5c832ca1847f2d9a8dc75b