### PR TITLE
Fix icon cut animation in game

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -12,6 +12,8 @@ interface FallingIcon {
   cut: boolean;
   animation: string;
   cutAnimation: string;
+  posY?: number;
+  rot?: number;
 }
 
 const icons = [
@@ -51,10 +53,16 @@ const Game = () => {
     return () => clearInterval(interval);
   }, [gameStarted, gameOverIcon]);
 
-  const handleCut = (id: number) => {
+  const handleCut = (id: number, el: HTMLDivElement) => {
     const anim = cutAnimations[Math.floor(Math.random() * cutAnimations.length)];
+    const style = window.getComputedStyle(el);
+    const matrix = new DOMMatrix(style.transform);
+    const posY = matrix.m42;
+    const rot = (Math.atan2(matrix.m21, matrix.m11) * 180) / Math.PI;
     setFalling(prev =>
-      prev.map(f => (f.id === id ? { ...f, cut: true, cutAnimation: anim } : f))
+      prev.map(f =>
+        f.id === id ? { ...f, cut: true, cutAnimation: anim, posY, rot } : f
+      )
     );
     setScore(prev => prev + 1);
   };
@@ -102,9 +110,17 @@ const Game = () => {
       {falling.map(icon => (
         <div
           key={icon.id}
-          className={`${styles.icon} ${styles[icon.animation]} ${icon.cut ? styles[icon.cutAnimation] : ''}`}
-          style={{ left: `${icon.left}%` }}
-          onClick={() => handleCut(icon.id)}
+          className={`${styles.icon} ${icon.cut ? styles[icon.cutAnimation] : styles[icon.animation]}`}
+          style={{
+            left: `${icon.left}%`,
+            ...(icon.cut
+              ? {
+                  '--ty': `${icon.posY ?? 0}px`,
+                  '--rot': `${icon.rot ?? 0}deg`,
+                }
+              : {}),
+          } as React.CSSProperties}
+          onClick={e => handleCut(icon.id, e.currentTarget)}
           onAnimationEnd={() => handleAnimationEnd(icon)}
         >
           {icon.Element}

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -13,6 +13,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  --ty: 0px;
+  --rot: 0deg;
   animation-timing-function: linear;
   animation-duration: 4s;
 }
@@ -112,11 +114,11 @@
 
 @keyframes cutAnim {
   from {
-    transform: rotate(0deg) scale(1);
+    transform: translateY(var(--ty)) rotate(var(--rot)) scale(1);
     opacity: 1;
   }
   to {
-    transform: rotate(60deg) scale(0.5);
+    transform: translateY(var(--ty)) rotate(calc(var(--rot) + 60deg)) scale(0.5);
     opacity: 0.3;
   }
 }
@@ -134,11 +136,11 @@
 
 @keyframes cutBloodAnim {
   from {
-    transform: rotate(0deg) scale(1);
+    transform: translateY(var(--ty)) rotate(var(--rot)) scale(1);
     opacity: 1;
   }
   to {
-    transform: rotate(120deg) scale(0.3);
+    transform: translateY(var(--ty)) rotate(calc(var(--rot) + 120deg)) scale(0.3);
     opacity: 0;
   }
 }
@@ -160,11 +162,11 @@
 
 @keyframes cutWindAnim {
   from {
-    transform: rotate(0deg) scale(1);
+    transform: translateY(var(--ty)) rotate(var(--rot)) scale(1);
     opacity: 1;
   }
   to {
-    transform: translateX(100px) rotate(90deg) scale(0.4);
+    transform: translateY(var(--ty)) translateX(100px) rotate(calc(var(--rot) + 90deg)) scale(0.4);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- preserve falling position when icons are sliced
- compute current transform on click
- drive cut animations with CSS variables

## Testing
- `npm test` *(fails: no tests found)*
- `npm run build` *(fails to build: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684044d1db90832cba5511c81a5edd91