### PR TITLE
Fix i18n text and add new game animations

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -10,11 +10,11 @@ const Navigation = () => {
 
   const navItems = [
     { path: '/', label: t('nav.home'), icon: (size: number) => <House size={size} /> },
-    { path: '/Contact', label: t('nav.contact'), icon: (size: number) => <EnvelopeSimple size={size} /> },
     { path: '/Technology', label: t('nav.technologies'), icon: (size: number) => <Cpu size={size} /> },
     { path: '/AI', label: t('nav.aiApproach'), icon: (size: number) => <Brain size={size} /> },
     { path: '/Patent', label: t('nav.patents'), icon: (size: number) => <FileText size={size} /> },
     { path: '/Game', label: t('nav.game'), icon: (size: number) => <GameController size={size} /> },
+    { path: '/Contact', label: t('nav.contact'), icon: (size: number) => <EnvelopeSimple size={size} /> },
   ];
 
   const navItemsWithConditionalLabels = navItems.map(item => ({

--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -31,7 +31,7 @@ const Game = () => {
   const [gameOverIcon, setGameOverIcon] = useState<FallingIcon | null>(null);
   const idRef = useRef(0);
   const animations = ['fall', 'fallRotate', 'fallSpin', 'fallColor'];
-  const cutAnimations = ['cut', 'cutBlood', 'cutWind'];
+  const cutAnimations = ['cut', 'cutBlood', 'cutWind', 'cutFade', 'cutFlip'];
 
   useEffect(() => {
     if (!gameStarted || gameOverIcon) return;

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -103,6 +103,17 @@
   animation: windTrail 0.5s forwards;
 }
 
+.icon.cutFade {
+  animation: cutFadeAnim 0.6s forwards;
+  position: relative;
+}
+
+.icon.cutFlip {
+  animation: cutFlipAnim 0.6s forwards;
+  position: relative;
+  transform-style: preserve-3d;
+}
+
 @keyframes fall {
   from {
     transform: translateY(-40px);
@@ -178,6 +189,28 @@
   }
   to {
     transform: translateY(-50%) scaleX(1);
+    opacity: 0;
+  }
+}
+
+@keyframes cutFadeAnim {
+  from {
+    transform: translateY(var(--ty)) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(var(--ty)) scale(0.2);
+    opacity: 0;
+  }
+}
+
+@keyframes cutFlipAnim {
+  from {
+    transform: translateY(var(--ty)) rotateY(0deg) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(var(--ty)) rotateY(180deg) scale(0.2);
     opacity: 0;
   }
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -502,7 +502,7 @@
     "connect": "İş Birliği ve Fikir Paylaşımı İçin Ulaşın"
   },
   "gameScreen": {
-    "tapToTrap": "Tap to Trap",
+    "tapToTrap": "Yakalamak için dokun",
     "score": "Puan",
     "gameOver": "Oyun Bitti",
     "missed": "{{platform}} ikonunu kesemediniz. Ziyaret etmek ister misiniz?",


### PR DESCRIPTION
## Summary
- fix TR localization for game start text
- reorder navigation menu items as requested
- add two new cut animations to the game
- allow game to randomly use the new animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6840b050d410832ca9da89c117a086af