### PR TITLE
Add pause and level mechanics to game

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -1,7 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
-import { GithubLogo, LinkedinLogo, TwitterLogo, YoutubeLogo } from 'phosphor-react';
+import {
+  GithubLogo,
+  LinkedinLogo,
+  TwitterLogo,
+  YoutubeLogo,
+  WhatsappLogo,
+  PhoneCall,
+  EnvelopeSimple,
+  Timer,
+  Pause,
+  Play
+} from 'phosphor-react';
 import { useTranslation } from 'react-i18next';
 import styles from '../styles/Game.module.css';
+
+const animations = ['fall', 'fallRotate', 'fallSpin', 'fallColor'];
 
 interface FallingIcon {
   id: number;
@@ -16,10 +29,17 @@ interface FallingIcon {
   rot?: number;
 }
 
+const encodedPhone = 'OTA1NTIyOTcyMTg1';
+const decodedPhone = () => atob(encodedPhone);
+
 const icons = [
+  { name: 'Call', Element: <PhoneCall size={64} />, url: `tel:${decodedPhone()}` },
+  { name: 'WhatsApp', Element: <WhatsappLogo size={64} />, url: `https://wa.me/${decodedPhone()}` },
   { name: 'LinkedIn', Element: <LinkedinLogo size={64} />, url: 'https://www.linkedin.com/in/hllbr/' },
+  { name: 'Email', Element: <EnvelopeSimple size={64} />, url: 'mailto:halibrahim.kocak@gmail.com' },
   { name: 'GitHub', Element: <GithubLogo size={64} />, url: 'https://github.com/hllbr' },
   { name: 'YouTube', Element: <YoutubeLogo size={64} />, url: 'https://www.youtube.com/@platonfarkndapaylasmlar637' },
+  { name: 'WakaTime', Element: <Timer size={64} />, url: 'https://wakatime.com/@HLLBR' },
   { name: 'Twitter', Element: <TwitterLogo size={64} />, url: 'https://twitter.com' },
 ];
 
@@ -32,12 +52,23 @@ const Game = () => {
   const [gameStarted, setGameStarted] = useState(false);
   const [score, setScore] = useState(0);
   const [gameOverIcon, setGameOverIcon] = useState<FallingIcon | null>(null);
+  const [paused, setPaused] = useState(false);
+  const [duration, setDuration] = useState(4);
+  const [delay, setDelay] = useState(1200);
+  const [congrats, setCongrats] = useState(false);
   const idRef = useRef(0);
-  const animations = ['fall', 'fallRotate', 'fallSpin', 'fallColor'];
-  const cutAnimations = ['cut', 'cutBlood', 'cutWind', 'cutFade', 'cutFlip'];
+  const cutAnimations = [
+    'cut',
+    'cutBlood',
+    'cutWind',
+    'cutFade',
+    'cutFlip',
+    'cutExplode',
+    'cutSlice'
+  ];
 
   useEffect(() => {
-    if (!gameStarted || gameOverIcon) return;
+    if (!gameStarted || gameOverIcon || paused) return;
     const interval = setInterval(() => {
       setFalling(prev => [
         ...prev,
@@ -52,9 +83,19 @@ const Game = () => {
           cutAnimation: 'cut',
         },
       ]);
-    }, 1200);
+    }, delay);
     return () => clearInterval(interval);
-  }, [gameStarted, gameOverIcon]);
+  }, [gameStarted, gameOverIcon, paused, delay]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'p') {
+        setPaused(p => !p);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
 
   const handleCut = (id: number, el: HTMLDivElement) => {
     const anim = cutAnimations[Math.floor(Math.random() * cutAnimations.length)];
@@ -84,8 +125,20 @@ const Game = () => {
     setFalling([]);
     setGameOverIcon(null);
     idRef.current = 0;
+    setPaused(false);
     setGameStarted(true);
   };
+
+  useEffect(() => {
+    const level = Math.floor(score / 10);
+    setDuration(Math.max(1.5, 4 - level * 0.4));
+    setDelay(Math.max(400, 1200 - level * 100));
+    if ([10, 25, 50, 75, 100].includes(score)) {
+      setCongrats(true);
+      const t = setTimeout(() => setCongrats(false), 1500);
+      return () => clearTimeout(t);
+    }
+  }, [score]);
 
   const closeModal = () => {
     setGameOverIcon(null);
@@ -107,15 +160,21 @@ const Game = () => {
       )}
       {gameStarted && (
         <div className={styles.scoreboard}>
-          {t('gameScreen.score')}: {score}
+          <span>{t('gameScreen.score')}: {score}</span>
+          <button className={styles.pauseBtn} onClick={() => setPaused(p => !p)}>
+            {paused ? <Play size={20} /> : <Pause size={20} />}
+          </button>
         </div>
       )}
+      {congrats && <div className={styles.congrats}>🎉</div>}
       {falling.map(icon => (
         <div
           key={icon.id}
           className={`${styles.icon} ${icon.cut ? styles[icon.cutAnimation] : styles[icon.animation]}`}
           style={{
             left: `${icon.left}%`,
+            animationDuration: `${duration}s`,
+            animationPlayState: paused ? 'paused' : 'running',
             ...(icon.cut
               ? {
                   '--ty': `${icon.posY ?? 0}px`,
@@ -123,7 +182,7 @@ const Game = () => {
                 }
               : {}),
           } as React.CSSProperties}
-          onClick={e => handleCut(icon.id, e.currentTarget)}
+          onClick={e => !paused && handleCut(icon.id, e.currentTarget)}
           onAnimationEnd={() => handleAnimationEnd(icon)}
         >
           {icon.Element}

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -114,6 +114,16 @@
   transform-style: preserve-3d;
 }
 
+.icon.cutExplode {
+  animation: cutExplodeAnim 0.5s forwards;
+  position: relative;
+}
+
+.icon.cutSlice {
+  animation: cutSliceAnim 0.5s forwards;
+  position: relative;
+}
+
 @keyframes fall {
   from {
     transform: translateY(-40px);
@@ -215,6 +225,28 @@
   }
 }
 
+@keyframes cutExplodeAnim {
+  from {
+    transform: translateY(var(--ty)) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(var(--ty)) scale(2.5);
+    opacity: 0;
+  }
+}
+
+@keyframes cutSliceAnim {
+  from {
+    transform: translateY(var(--ty)) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(var(--ty)) rotate(360deg) scale(0.3);
+    opacity: 0;
+  }
+}
+
 @keyframes fallRotate {
   from {
     transform: translateY(-40px) rotate(0deg);
@@ -247,13 +279,45 @@
 .scoreboard {
   position: absolute;
   top: 8px;
-  right: 8px;
+  left: 50%;
+  transform: translateX(-50%);
   padding: 0.3rem 0.7rem;
   background: rgba(15, 23, 42, 0.7);
   color: #38bdf8;
   border-radius: 6px;
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   z-index: 2;
+}
+
+.pauseBtn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.congrats {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(56, 189, 248, 0.9);
+  color: #0f172a;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: 700;
+  z-index: 2;
+  animation: fadeOut 2s forwards;
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 .startOverlay {


### PR DESCRIPTION
## Summary
- center scoreboard and add pause/resume button
- include all social icons in game
- add cut explosion and slice animations
- implement pause logic and speed progression
- show congrats message on milestone scores

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840bd4dfcf0832c9ebfa7d0402f25af