### PR TITLE
Improve game cut logic and add visible boundary

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -99,9 +99,10 @@ const Game = () => {
 
   const handleCut = (id: number, el: HTMLDivElement) => {
     const anim = cutAnimations[Math.floor(Math.random() * cutAnimations.length)];
-    const style = window.getComputedStyle(el);
-    const matrix = new DOMMatrix(style.transform);
-    const posY = matrix.m42;
+    const matrix = new DOMMatrix(window.getComputedStyle(el).transform);
+    const containerRect = el.parentElement?.getBoundingClientRect();
+    const rect = el.getBoundingClientRect();
+    const posY = rect.top - (containerRect?.top ?? 0);
     const rot = (Math.atan2(matrix.m21, matrix.m11) * 180) / Math.PI;
     setFalling(prev =>
       prev.map(f =>

--- a/src/features/Game/styles/Game.module.css
+++ b/src/features/Game/styles/Game.module.css
@@ -3,6 +3,7 @@
   width: 100%;
   height: 70vh;
   overflow: hidden;
+  border-bottom: 4px dashed #f87171;
 }
 
 .icon {
@@ -390,6 +391,7 @@
 @media (max-width: 640px) {
   .container {
     height: 60vh;
+    border-bottom: 4px dashed #f87171;
   }
   .startOverlay {
     font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- ensure falling icons freeze exactly where clicked
- highlight the bottom edge as the game-over boundary

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840c0e7f824832c966ad05ea538cdb3