### PR TITLE
Refactor inline styles to Tailwind classes

### DIFF
--- a/src/components/ui/FluidTabs.tsx
+++ b/src/components/ui/FluidTabs.tsx
@@ -55,60 +55,26 @@ const FluidTabs: React.FC<FluidTabsProps> = ({ items }) => {
 
   return (
     <LayoutGroup>
-      <div style={{
-        display: 'flex',
-        background: 'rgba(30,41,59,0.92)',
-        borderRadius: 999,
-        padding: 4,
-        boxShadow: '0 2px 12px 0 rgba(31,38,135,0.08)',
-        gap: containerGap,
-        justifyContent: 'center',
-        alignItems: 'center',
-        margin: '0 auto',
-        minHeight: containerMinHeight,
-        width: 'fit-content',
-        position: 'relative',
-      }}>
+      <div
+        className={`flex bg-slate-800/90 rounded-full p-1 shadow-[0_2px_12px_0_rgba(31,38,135,0.08)] justify-center items-center mx-auto w-fit relative ${isMobile ? 'gap-2 min-h-[36px]' : 'gap-4 min-h-[48px]'}`}
+      >
         {items.map((item, i) => {
           const selected = i === current;
           return (
             <button
               key={item.path}
               onClick={() => navigate(item.path)}
-              style={{
-                position: 'relative',
-                border: 'none',
-                background: 'none',
-                color: selected ? '#0ea5e9' : '#e2e8f0',
-                fontWeight: selected ? 700 : 500,
-                fontSize: buttonFontSize,
-                borderRadius: 999,
-                padding: buttonPadding,
-                cursor: 'pointer',
-                outline: 'none',
-                zIndex: 1,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                transition: 'color 0.18s',
-              }}
+              className={`relative border-none bg-none ${selected ? 'text-sky-500 font-bold' : 'text-slate-200 font-medium'} ${isMobile ? 'py-[0.4rem] px-[0.7rem] text-[15px]' : 'py-[0.65rem] px-[1.5rem] text-[18px]'} cursor-pointer outline-none z-[1] flex items-center gap-2 transition-colors duration-150`}
               aria-current={selected ? 'page' : undefined}
             >
               {selected && (
                 <motion.div
                   layoutId="fluid-tab-bg"
-                  style={{
-                    position: 'absolute',
-                    inset: 0,
-                    borderRadius: 999,
-                    background: 'rgba(255,255,255,0.08)',
-                    boxShadow: '0 2px 8px 0 rgba(56,189,248,0.08)',
-                    zIndex: -1,
-                  }}
+                  className="absolute inset-0 rounded-full bg-white/10 shadow-[0_2px_8px_0_rgba(56,189,248,0.08)] z-[-1]"
                   transition={{ type: 'spring', bounce: 0.32, duration: 0.5 }}
                 />
               )}
-              {item.icon && <span style={{ marginRight: 8 }}>{item.icon(iconSize)}</span>}
+              {item.icon && <span className="mr-2">{item.icon(iconSize)}</span>}
               {item.label}
             </button>
           );
@@ -116,78 +82,31 @@ const FluidTabs: React.FC<FluidTabsProps> = ({ items }) => {
         <button
           ref={langMenuRef}
           onClick={() => setLangMenuOpen(v => !v)}
-          style={{
-            position: 'relative',
-            zIndex: 20,
-            pointerEvents: 'auto',
-            border: 'none',
-            background: 'none',
-            color: '#e2e8f0',
-            borderRadius: 999,
-            padding: buttonPadding,
-            cursor: 'pointer',
-            outline: 'none',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            transition: 'color 0.18s',
-            marginLeft: 8,
-          }}
+          className={`relative z-20 pointer-events-auto border-none bg-none text-slate-200 rounded-full cursor-pointer outline-none flex items-center gap-2 transition-colors duration-150 ml-2 ${isMobile ? 'py-[0.4rem] px-[0.7rem]' : 'py-[0.65rem] px-[1.5rem]'}`}
           aria-label="Change language"
         >
           <Translate size={isMobile ? 24 : 32} />
         </button>
         {langMenuOpen && (
-          <div style={{
-            position: 'absolute',
-            right: 0,
-            top: '110%',
-            background: 'rgba(30,41,59,0.98)',
-            borderRadius: 12,
-            boxShadow: '0 4px 24px 0 rgba(31,38,135,0.18)',
-            padding: '0.5rem 1.2rem',
-            minWidth: 120,
-            zIndex: 30,
-            pointerEvents: 'auto',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 8,
-            border: '2px solid #0ea5e9',
-          }}>
+          <div
+            className="absolute right-0 bg-slate-800/95 rounded-xl shadow-[0_4px_24px_0_rgba(31,38,135,0.18)] py-2 px-[1.2rem] min-w-[120px] z-30 pointer-events-auto flex flex-col items-center gap-2 border-2 border-sky-500"
+            style={{ top: '110%' }}
+          >
             <button
               onClick={e => { e.stopPropagation(); i18n.changeLanguage('en'); setLangMenuOpen(false); }}
-              style={{
-                background: i18n.language === 'en' ? '#0ea5e9' : 'none',
-                color: i18n.language === 'en' ? '#fff' : '#e2e8f0',
-                border: 'none',
-                borderRadius: 8,
-                fontWeight: 600,
-                fontSize: 16,
-                padding: '0.4rem 1.2rem',
-                cursor: 'pointer',
-                width: '100%',
-                transition: 'background 0.18s, color 0.18s',
-              }}
-            >EN</button>
+              className={`w-full rounded-lg font-semibold text-base cursor-pointer transition-colors duration-150 py-[0.4rem] px-[1.2rem] ${i18n.language === 'en' ? 'bg-sky-500 text-white' : 'bg-transparent text-slate-200'}`}
+            >
+              EN
+            </button>
             <button
               onClick={e => { e.stopPropagation(); i18n.changeLanguage('tr'); setLangMenuOpen(false); }}
-              style={{
-                background: i18n.language === 'tr' ? '#0ea5e9' : 'none',
-                color: i18n.language === 'tr' ? '#fff' : '#e2e8f0',
-                border: 'none',
-                borderRadius: 8,
-                fontWeight: 600,
-                fontSize: 16,
-                padding: '0.4rem 1.2rem',
-                cursor: 'pointer',
-                width: '100%',
-                transition: 'background 0.18s, color 0.18s',
-              }}
-            >TR</button>
+              className={`w-full rounded-lg font-semibold text-base cursor-pointer transition-colors duration-150 py-[0.4rem] px-[1.2rem] ${i18n.language === 'tr' ? 'bg-sky-500 text-white' : 'bg-transparent text-slate-200'}`}
+            >
+              TR
+            </button>
           </div>
         )}
-        <span style={{display:'none'}}>{t('language')}</span>
+        <span className="hidden">{t('language')}</span>
       </div>
     </LayoutGroup>
   );

--- a/src/features/Contact/components/Contact.tsx
+++ b/src/features/Contact/components/Contact.tsx
@@ -101,7 +101,7 @@ const Contact = () => {
 
         <section className="space-y-6 mt-8">
           <form onSubmit={handleSubmit} className={styles.form}>
-            <div style={{ position: 'relative' }}>
+            <div className="relative">
               <label htmlFor="name" className="block text-sm font-medium mb-1">
                 {t('contact.form.name', 'Name')}
               </label>
@@ -115,7 +115,7 @@ const Contact = () => {
                 onChange={handleInputChange}
               />
             </div>
-            <div style={{ position: 'relative' }}>
+            <div className="relative">
               <label htmlFor="email" className="block text-sm font-medium mb-1">
                 {t('contact.form.email', 'Email')}
               </label>
@@ -129,7 +129,7 @@ const Contact = () => {
                 onChange={handleInputChange}
               />
             </div>
-            <div style={{ position: 'relative' }}>
+            <div className="relative">
               <label htmlFor="subject" className="block text-sm font-medium mb-1">
                 {t('contact.form.subject', 'Subject')}
               </label>
@@ -143,7 +143,7 @@ const Contact = () => {
                 onChange={handleInputChange}
               />
             </div>
-            <div style={{ position: 'relative' }}>
+            <div className="relative">
               <label htmlFor="message" className="block text-sm font-medium mb-1">
                 {t('contact.form.message', 'Message')}
               </label>

--- a/src/features/Contact/components/ContactSocialButtons.tsx
+++ b/src/features/Contact/components/ContactSocialButtons.tsx
@@ -13,12 +13,11 @@ const ContactSocialButtons = () => {
   };
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', gap: '32px', marginBottom: '1.5rem' }}>
+    <div className="flex justify-center gap-8 mb-6">
       <button
         onClick={handleCall}
-        className="social-link"
+        className="social-link bg-transparent border-none p-0 cursor-pointer"
         title="Call"
-        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
       >
         <Phone size={32} />
       </button>

--- a/src/features/Contact/components/Tooltip.tsx
+++ b/src/features/Contact/components/Tooltip.tsx
@@ -13,7 +13,7 @@ interface TooltipProps {
 const Tooltip = ({ label, t }: TooltipProps) => (
   <div className={styles.tooltipBox}>
     <div className={styles.tooltipArrow} />
-    <WarningCircle size={20} color="#faad14" weight="fill" style={{ flexShrink: 0, zIndex: 12 }} />
+    <WarningCircle size={20} color="#faad14" weight="fill" className="flex-shrink-0 z-[12]" />
     <span className={styles.tooltipText}>
       <b>{label}</b> {label && ' '}{t('contact.form.mustBeFilled')}
     </span>


### PR DESCRIPTION
## Summary
- switch buttons in `FluidTabs` to Tailwind CSS classes
- convert social buttons to use Tailwind layout
- refactor Tooltip icon to use Tailwind classes
- clean up Contact form wrappers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684165d1c0cc832c803a5895c21c1369