### PR TITLE
Fix Game icon cut position

### DIFF
--- a/src/features/Game/components/Game.tsx
+++ b/src/features/Game/components/Game.tsx
@@ -98,9 +98,7 @@ const Game = () => {
   const handleCut = (id: number, el: HTMLDivElement) => {
     const anim = cutAnimations[Math.floor(Math.random() * cutAnimations.length)];
     const matrix = new DOMMatrix(window.getComputedStyle(el).transform);
-    const containerRect = el.parentElement?.getBoundingClientRect();
-    const rect = el.getBoundingClientRect();
-    const posY = rect.top - (containerRect?.top ?? 0);
+    const posY = matrix.m42;
     const rot = (Math.atan2(matrix.m21, matrix.m11) * 180) / Math.PI;
     setFalling(prev =>
       prev.map(f =>


### PR DESCRIPTION
## Summary
- compute Y position for cut animation using the element's transform matrix

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68432bc9992c832cb3c482e2976024d2